### PR TITLE
Sequential

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -61,5 +61,4 @@ jobs:
       run: |
         poetry install -E dev
         poetry run ruff check .
-        poetry run isort --check-only .
         poetry run mypy .

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,4 +1,4 @@
-name: dev build CI
+name: CI
 
 # Controls when the action will run.
 on:
@@ -52,13 +52,15 @@ jobs:
         STAR --version
         samtools --version
 
-    - name: test
+    - name: Install project dependencies
       run: |
         poetry install -E dev
+
+    - name: test
+      run: |
         poetry run pytest
 
     - name: linting and type checking
       run: |
-        poetry install -E dev
         poetry run ruff check .
         poetry run mypy .

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -63,4 +63,3 @@ jobs:
     - name: linting and type checking
       run: |
         poetry run ruff check .
-        poetry run mypy .

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -57,48 +57,9 @@ jobs:
         poetry install -E dev
         poetry run pytest
 
-  publish_dev_build:
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pages: write
-      id-token: write
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-
-    - name: Install Poetry
+    - name: linting and type checking
       run: |
-        python -m pip install --upgrade pip
-        pip install poetry
-
-    - name: Install dependencies
-      run: |
-        poetry install -E doc
-
-    - name: Build documentation
-      run: |
-        poetry run mkdocs build
-
-    - name: Configure git identity
-      run: |
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-    - name: Configure git auth
-      run: |
-        git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
-
-    - name: Publish with mike
-      run: |
-        VERSION="$(poetry version --short).dev"
-        # If your Pages branch is not gh-pages, add: -b <branch>
-        poetry run mike deploy -p "$VERSION"
-        poetry run mike set-default -p "$VERSION"
+        poetry install -E dev
+        poetry run ruff check .
+        poetry run isort --check-only .
+        poetry run mypy .

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,53 @@
+name: dev build CI
+
+# Controls when the action will run.
+on:
+  release:
+    types: [published]
+
+# contains 3 jobs: test, publish_dev_build and notification
+jobs:
+  publish_dev_build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install Poetry
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+
+    - name: Install dependencies
+      run: |
+        poetry install -E doc
+
+    - name: Build documentation
+      run: |
+        poetry run mkdocs build
+
+    - name: Configure git identity
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Configure git auth
+      run: |
+        git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+
+    - name: Publish with mike
+      run: |
+        VERSION="$(poetry version --short).dev"
+        # If your Pages branch is not gh-pages, add: -b <branch>
+        poetry run mike deploy -p "$VERSION"
+        poetry run mike set-default -p "$VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Changelog
 
-## Version 2.1.0
+## Version 2.1.0
 * Added extra STAR parameters for reads filtering (@johnne)
 * Added Docker build action (@johnne)
 * Update Docker recipe (@johnne)
 * Fix a bug when using --disable-mapping (@johnne)
-*
 
 ## Version 2.0.0
 * Refactor code to modern Python (black, mypy, isort)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,6 +72,8 @@ st_pipeline_run [options] fastq_file_fw fastq_file_rv
                         Path of the location for temporary files
   --keep-discarded-files
                         Keep files with discarded reads in every step
+  --force               Overwrite existing files (affects 'R2_quality_trimmed.bam' 
+                        and 'demultiplexed_matched.bam')
   --qual-64             Use phred-64 quality instead of phred-33(default) in
                         the quality trimming step
   --min-length-qual-trimming [INT]

--- a/makefile
+++ b/makefile
@@ -4,18 +4,17 @@ sources = stpipeline
 test: format lint unittest
 
 format:
-	poetry run isort $(sources) tests
-	poetry run  ruff format $(sources) tests
+	poetry run ruff format $(sources) tests
 
 lint:
 	poetry run ruff check --fix $(sources) tests
-	poetry run  mypy $(sources)
+	poetry run mypy $(sources)
 
 unittest:
-	poetry run  pytest
+	poetry run pytest
 
 coverage:
-	poetry run  pytest --cov=$(sources) --cov-branch --cov-report=term-missing tests
+	poetry run pytest --cov=$(sources) --cov-branch --cov-report=term-missing tests
 
 pre-commit:
 	pre-commit run --all-files

--- a/poetry.lock
+++ b/poetry.lock
@@ -2545,4 +2545,4 @@ doc = ["mike", "mkdocs", "mkdocs-autorefs", "mkdocs-include-markdown-plugin", "m
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "b95e6e20a21069d9e73e7758241dd924f4ae5d6217f6a81e1bd5cd85ac9af1f9"
+content-hash = "ea16c625a0e039c26d2269c2a6eaac0a15196fa2859a321633accf8d5f93d07b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dev = [
     "toml",
     "ruff",
     "isort",
+    "mypy",
     "pytest",
     "pytest-cov"
     ]

--- a/stpipeline/core/pipeline.py
+++ b/stpipeline/core/pipeline.py
@@ -151,11 +151,7 @@ class Pipeline:
                 shutil.rmtree(star_temp1)
             if os.path.isdir(star_temp2):
                 shutil.rmtree(star_temp2)
-            if (
-                self.clean
-                and not self.keep_discarded_files
-                and self.temp_folder != self.output_folder
-            ):
+            if self.clean and not self.keep_discarded_files and self.temp_folder != self.output_folder:
                 shutil.rmtree(self.temp_folder)
 
     def sanityCheck(self) -> None:
@@ -207,7 +203,9 @@ class Pipeline:
 
         # Check for presence of 'mapped.bam' if --disable-mapping is set
         if self.disable_mapping and not os.path.exists(os.path.join(self.temp_folder, FILENAMES["mapped"])):  # type: ignore[call-overload]
-            error = f"Error argument '--disable-mapping' is set but {FILENAMES['mapped']} is missing in {self.temp_folder}."
+            error = (
+                f"Error argument '--disable-mapping' is set but {FILENAMES['mapped']} is missing in {self.temp_folder}."
+            )
             logger.error(error)
             raise RuntimeError(error)
 
@@ -222,9 +220,7 @@ class Pipeline:
             raise RuntimeError(error)
 
         if self.saturation_points is not None and not self.compute_saturation:
-            logger.warning(
-                "Saturation points are provided but the option to compute saturation is disabled."
-            )
+            logger.warning("Saturation points are provided but the option to compute saturation is disabled.")
 
         if not self.disable_umi and self.umi_filter:
             # Check template validity
@@ -234,9 +230,7 @@ class Pipeline:
                 logger.error(error)
                 raise RuntimeError(error)
             # Check template length
-            if len(self.umi_filter_template) != (
-                self.umi_end_position - self.umi_start_position
-            ):
+            if len(self.umi_filter_template) != (self.umi_end_position - self.umi_start_position):
                 error = f"Error the UMI template given does not have the correct length {self.umi_filter_template}."
                 logger.error(error)
                 raise RuntimeError(error)
@@ -279,7 +273,9 @@ class Pipeline:
 
         # Add checks for trimming parameters, demultiplex parameters and UMI parameters
         if self.allowed_missed > self.allowed_kmer and not self.disable_barcode:
-            error = "Error starting the pipeline.\nTaggd allowed mismatches is bigger or equal than the Taggd k-mer size"
+            error = (
+                "Error starting the pipeline.\nTaggd allowed mismatches is bigger or equal than the Taggd k-mer size"
+            )
             logger.error(error)
             raise RuntimeError(error)
 
@@ -295,11 +291,7 @@ class Pipeline:
             logger.error(error)
             raise RuntimeError(error)
 
-        if (
-            self.umi_allowed_mismatches
-            > (self.umi_end_position - self.umi_start_position)
-            and not self.disable_umi
-        ):
+        if self.umi_allowed_mismatches > (self.umi_end_position - self.umi_start_position) and not self.disable_umi:
             error = "Error starting the pipeline.\nThe allowed UMI mismatches is bigger than the UMI size"
             logger.error(error)
             raise RuntimeError(error)
@@ -320,9 +312,7 @@ class Pipeline:
             logger.error(error)
             raise RuntimeError(error)
 
-    def createParameters(
-        self, parser: argparse.ArgumentParser
-    ) -> argparse.ArgumentParser:
+    def createParameters(self, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         """
         Adds the pipeline"s parameters to a given
         Argparse object and returns it.
@@ -332,15 +322,11 @@ class Pipeline:
             def __call__(self, parser, namespace, values, option_string=None) -> None:  # type: ignore
                 prospective_dir = values
                 if not os.path.isdir(prospective_dir):
-                    raise argparse.ArgumentTypeError(
-                        f"{prospective_dir} is not a valid path"
-                    )
+                    raise argparse.ArgumentTypeError(f"{prospective_dir} is not a valid path")
                 if os.access(prospective_dir, os.R_OK):
                     setattr(namespace, self.dest, prospective_dir)
                 else:
-                    raise argparse.ArgumentTypeError(
-                        f"{prospective_dir} is not a readable dir"
-                    )
+                    raise argparse.ArgumentTypeError(f"{prospective_dir} is not a readable dir")
 
         parser.add_argument("fastq_files", nargs=2)
         parser.add_argument(
@@ -449,8 +435,7 @@ class Pipeline:
             metavar="[INT]",
             type=int,
             choices=range(5, 151),
-            help="Minimum length of the reads after trimming, "
-            "shorter reads will be discarded (default: %(default)s)",
+            help="Minimum length of the reads after trimming, shorter reads will be discarded (default: %(default)s)",
         )
         parser.add_argument(
             "--min-quality-trimming",
@@ -483,8 +468,7 @@ class Pipeline:
             metavar="[INT]",
             type=int,
             choices=range(0, 35),
-            help="Remove PolyG stretches of the given length from R2 "
-            "(Use 0 to disable it) (default: %(default)s)",
+            help="Remove PolyG stretches of the given length from R2 (Use 0 to disable it) (default: %(default)s)",
         )
         parser.add_argument(
             "--remove-polyC",
@@ -614,8 +598,7 @@ class Pipeline:
             "--star-min-score-ratio",
             default=0.66,
             type=float,
-            help="Minimum alignment score (as above) but normalized to"
-            "\nread length. (default: 0.66)",
+            help="Minimum alignment score (as above) but normalized to\nread length. (default: 0.66)",
         )
         parser.add_argument(
             "--star-min-matched-bases",
@@ -630,8 +613,7 @@ class Pipeline:
             "--star-min-matched-bases-ratio",
             default=0.66,
             type=float,
-            help="Minimum matched bases (as above) but normalized to"
-            "\nread length. (default: 0.66)",
+            help="Minimum matched bases (as above) but normalized to\nread length. (default: 0.66)",
         )
         parser.add_argument(
             "--demultiplexing-mismatches",
@@ -862,9 +844,7 @@ class Pipeline:
             help="Use this flag if you want to use transcriptome instead of a genome, the gene tag will be "
             "obtained from the transcriptome file",
         )
-        parser.add_argument(
-            "--version", action="version", version="%(prog)s " + str(version_number)
-        )
+        parser.add_argument("--version", action="version", version="%(prog)s " + str(version_number))
         return parser
 
     def load_parameters(self, options: argparse.Namespace) -> None:
@@ -935,9 +915,7 @@ class Pipeline:
         self.umi_quality_bases = options.umi_quality_bases
         self.umi_counting_offset = options.umi_counting_offset
         self.taggd_metric = options.demultiplexing_metric
-        self.taggd_multiple_hits_keep_one = (
-            options.demultiplexing_multiple_hits_keep_one
-        )
+        self.taggd_multiple_hits_keep_one = options.demultiplexing_multiple_hits_keep_one
         self.taggd_trim_sequences = options.demultiplexing_trim_sequences
         self.taggd_chunk_size = options.demultiplexing_chunk_size
         self.adaptor_missmatches = options.homopolymer_mismatches
@@ -956,11 +934,7 @@ class Pipeline:
             self.saturation_points = [int(p) for p in options.saturation_points]  # type: ignore
         # Assign class parameters to the QA stats object
         attributes = inspect.getmembers(self, lambda a: not (inspect.isroutine(a)))
-        attributes_filtered = {
-            a[0]: a[1]
-            for a in attributes
-            if not (a[0].startswith("__") and a[0].endswith("__"))
-        }
+        attributes_filtered = {a[0]: a[1] for a in attributes if not (a[0].startswith("__") and a[0].endswith("__"))}
         # Assign general parameters to the qa_stats object
         self.qa_stats.input_parameters = attributes_filtered  # type: ignore
         self.qa_stats.annotation_tool = f"htseq-count {get_htseq_count_version()}"
@@ -990,45 +964,25 @@ class Pipeline:
         if self.ref_annotation is not None:
             logger.info(f"Reference annotation file: {self.ref_annotation}")
         if self.contaminant_index is not None:
-            logger.info(
-                f"Using contamination filter STAR index: {self.contaminant_index}"
-            )
+            logger.info(f"Using contamination filter STAR index: {self.contaminant_index}")
         logger.info(f"CPU Nodes: {self.threads}")
 
         if not self.disable_trimming:
             logger.info("Quality and trimming settings")
-            logger.info(
-                f"Discarding reads that after trimming are shorter than {self.min_length_trimming}"
-            )
+            logger.info(f"Discarding reads that after trimming are shorter than {self.min_length_trimming}")
             if self.remove_polyA_distance > 0:
-                logger.info(
-                    f"Removing polyA sequences of a length of at least: {self.remove_polyA_distance}"
-                )
+                logger.info(f"Removing polyA sequences of a length of at least: {self.remove_polyA_distance}")
             if self.remove_polyT_distance > 0:
-                logger.info(
-                    f"Removing polyT sequences of a length of at least: {self.remove_polyT_distance}"
-                )
+                logger.info(f"Removing polyT sequences of a length of at least: {self.remove_polyT_distance}")
             if self.remove_polyG_distance > 0:
-                logger.info(
-                    f"Removing polyG sequences of a length of at least: {self.remove_polyG_distance}"
-                )
+                logger.info(f"Removing polyG sequences of a length of at least: {self.remove_polyG_distance}")
             if self.remove_polyC_distance > 0:
-                logger.info(
-                    f"Removing polyC sequences of a length of at least: {self.remove_polyC_distance}"
-                )
+                logger.info(f"Removing polyC sequences of a length of at least: {self.remove_polyC_distance}")
             if self.remove_polyN_distance > 0:
-                logger.info(
-                    f"Removing polyN sequences of a length of at least: {self.remove_polyN_distance}"
-                )
-            logger.info(
-                f"Allowing {self.adaptor_missmatches} mismatches when removing homopolymers"
-            )
-            logger.info(
-                f"Discarding reads whose AT content is {self.filter_AT_content}%"
-            )
-            logger.info(
-                f"Discarding reads whose GC content is {self.filter_GC_content}%"
-            )
+                logger.info(f"Removing polyN sequences of a length of at least: {self.remove_polyN_distance}")
+            logger.info(f"Allowing {self.adaptor_missmatches} mismatches when removing homopolymers")
+            logger.info(f"Discarding reads whose AT content is {self.filter_AT_content}%")
+            logger.info(f"Discarding reads whose GC content is {self.filter_GC_content}%")
         else:
             logger.info("Disabling Quality trimming step")
 
@@ -1037,20 +991,12 @@ class Pipeline:
             logger.info(f"Mapping reverse trimming: {self.trimming_rv}")
             logger.info(f"Mapping inverse reverse trimming: {self.inverse_trimming_rv}")
             logger.info("Mapping tool: STAR")
-            logger.info(
-                f"Mapping minimum intron size allowed (splice alignments) with STAR: {self.min_intron_size}"
-            )
-            logger.info(
-                f"Mapping maximum intron size allowed (splice alignments) with STAR: {self.max_intron_size}"
-            )
+            logger.info(f"Mapping minimum intron size allowed (splice alignments) with STAR: {self.min_intron_size}")
+            logger.info(f"Mapping maximum intron size allowed (splice alignments) with STAR: {self.max_intron_size}")
             logger.info(f"STAR genome loading strategy: {self.star_genome_loading}")
             logger.info(f"STAR minimum alignment score: {self.star_min_score}")
-            logger.info(
-                f"STAR minimum alignment score ratio: {self.star_min_score_ratio}"
-            )
-            logger.info(
-                f"STAR minimum matched bases ratio: {self.star_min_matched_bases_ratio}"
-            )
+            logger.info(f"STAR minimum alignment score ratio: {self.star_min_score_ratio}")
+            logger.info(f"STAR minimum matched bases ratio: {self.star_min_matched_bases_ratio}")
             if self.disable_clipping:
                 logger.info("Not allowing soft clipping when mapping with STAR")
             if self.disable_multimap:
@@ -1070,10 +1016,8 @@ class Pipeline:
             if self.taggd_multiple_hits_keep_one:
                 logger.info("TaggD multiple hits keep one (random) is enabled")
             if self.taggd_trim_sequences is not None:
-                logger.info(
-                    f"TaggD trimming from the barcodes: {'-'.join(str(x) for x in self.taggd_trim_sequences)}"
-                )
-            logger.info(f"TaggD chunk size: {self.taggd_chunk_size }")
+                logger.info(f"TaggD trimming from the barcodes: {'-'.join(str(x) for x in self.taggd_trim_sequences)}")
+            logger.info(f"TaggD chunk size: {self.taggd_chunk_size}")
         else:
             logger.info("Disabling Demultiplexing step")
 
@@ -1095,9 +1039,7 @@ class Pipeline:
         if self.compute_saturation:
             logger.info("Computing saturation curve with several sub-samples...")
             if self.saturation_points is not None:
-                logger.info(
-                    f"Using the following points: {' '.join(str(p) for p in self.saturation_points)}"
-                )
+                logger.info(f"Using the following points: {' '.join(str(p) for p in self.saturation_points)}")
 
         if not self.disable_umi:
             logger.info("UMI Collapsing settings")
@@ -1108,9 +1050,7 @@ class Pipeline:
             logger.info(
                 f"Allowing an offset of {self.umi_counting_offset} when clustering UMIs by strand-start in a gene-spot"
             )
-            logger.info(
-                f"Allowing {self.umi_quality_bases} low quality bases in an UMI"
-            )
+            logger.info(f"Allowing {self.umi_quality_bases} low quality bases in an UMI")
             if self.umi_filter:
                 logger.info(f"UMIs using filter: {self.umi_filter_template}")
         else:
@@ -1153,11 +1093,7 @@ class Pipeline:
                     self.fastq_fw,
                     self.fastq_rv,
                     FILENAMES["quality_trimmed_R2"],
-                    (
-                        FILENAMES_DISCARDED["quality_trimmed_discarded"]
-                        if self.keep_discarded_files
-                        else None
-                    ),
+                    (FILENAMES_DISCARDED["quality_trimmed_discarded"] if self.keep_discarded_files else None),
                     barcode_length,
                     self.barcode_start,
                     self.filter_AT_content,
@@ -1188,9 +1124,7 @@ class Pipeline:
             except Exception:
                 raise
         else:
-            logger.info(
-                f"Using already existing {FILENAMES['quality_trimmed_R2']} file"
-            )
+            logger.info(f"Using already existing {FILENAMES['quality_trimmed_R2']} file")
 
         # =================================================================
         # CONDITIONAL STEP: Filter out contaminated reads, e.g. rRNA(Optional)
@@ -1198,9 +1132,7 @@ class Pipeline:
         if self.contaminant_index:
             # To remove contaminants sequence we align the reads to the contaminant genome
             # and keep the un-mapped reads
-            logger.info(
-                f"Starting contaminant filter alignment {globaltime.get_timestamp()}"
-            )
+            logger.info(f"Starting contaminant filter alignment {globaltime.get_timestamp()}")
             try:
                 # Make the contaminant filter call
                 alignReads(
@@ -1229,15 +1161,9 @@ class Pipeline:
                 # NOTE: this will not be needed when STAR allows to chose the discarded
                 # reads format (BAM)
                 # We also need to set the NH tag to Null so to be able to run STAR again
-                infile = pysam.AlignmentFile(
-                    FILENAMES_DISCARDED["contaminated_discarded"], "rb"
-                )
-                out_unmap = pysam.AlignmentFile(
-                    FILENAMES["contaminated_clean"], "wb", template=infile
-                )
-                temp_name = os.path.join(
-                    self.temp_folder, next(tempfile._get_candidate_names())
-                )
+                infile = pysam.AlignmentFile(FILENAMES_DISCARDED["contaminated_discarded"], "rb")
+                out_unmap = pysam.AlignmentFile(FILENAMES["contaminated_clean"], "wb", template=infile)
+                temp_name = os.path.join(self.temp_folder, next(tempfile._get_candidate_names()))
                 out_map = pysam.AlignmentFile(temp_name, "wb", template=infile)
                 for sam_record in infile.fetch(until_eof=True):
                     try:
@@ -1266,9 +1192,7 @@ class Pipeline:
         # =================================================================
         if not self.disable_mapping:
             input_mapping = (
-                FILENAMES["contaminated_clean"]
-                if self.contaminant_index
-                else FILENAMES["quality_trimmed_R2"]
+                FILENAMES["contaminated_clean"] if self.contaminant_index else FILENAMES["quality_trimmed_R2"]
             )
             logger.info(f"Starting genome alignment {globaltime.get_timestamp()}")
             try:
@@ -1317,9 +1241,7 @@ class Pipeline:
         # =================================================================
         if not self.disable_barcode:
             if not os.path.exists(FILENAMES["demultiplexed_matched"]) or self.force:
-                logger.info(
-                    f"Starting barcode demultiplexing {globaltime.get_timestamp()}"
-                )
+                logger.info(f"Starting barcode demultiplexing {globaltime.get_timestamp()}")
                 try:
                     stats = barcodeDemultiplexing(  # type: ignore
                         FILENAMES["mapped"],
@@ -1349,9 +1271,7 @@ class Pipeline:
                 except Exception:
                     raise
             else:
-                logger.info(
-                    f"Using already existing {FILENAMES['demultiplexed_matched']} file"
-                )
+                logger.info(f"Using already existing {FILENAMES['demultiplexed_matched']} file")
         else:
             FILENAMES["demultiplexed_matched"] = FILENAMES["mapped"]
 
@@ -1360,9 +1280,7 @@ class Pipeline:
         # =================================================================
         if not self.disable_annotation:
             if self.transcriptome:
-                logger.info(
-                    f"Assigning gene names from transcriptome {globaltime.get_timestamp()}"
-                )
+                logger.info(f"Assigning gene names from transcriptome {globaltime.get_timestamp()}")
                 # Iterate the BAM file to set the gene name as the transcriptome"s entry
                 flag_read = "rb"
                 flag_write = "wb"
@@ -1382,11 +1300,7 @@ class Pipeline:
                         FILENAMES["demultiplexed_matched"],
                         self.ref_annotation,  # type: ignore
                         FILENAMES["annotated"],
-                        (
-                            FILENAMES_DISCARDED["annotated_discarded"]
-                            if self.keep_discarded_files
-                            else None
-                        ),
+                        (FILENAMES_DISCARDED["annotated_discarded"] if self.keep_discarded_files else None),
                         self.htseq_mode,
                         self.strandness,
                         self.htseq_no_ambiguous,
@@ -1409,9 +1323,7 @@ class Pipeline:
                 if not self.transcriptome
                 else self.qa_stats.reads_after_demultiplexing
             )
-            logger.info(
-                f"Starting computing saturation points {globaltime.get_timestamp()}"
-            )
+            logger.info(f"Starting computing saturation points {globaltime.get_timestamp()}")
             try:
                 compute_saturation(
                     nreads,

--- a/stpipeline/core/pipeline.py
+++ b/stpipeline/core/pipeline.py
@@ -151,7 +151,11 @@ class Pipeline:
                 shutil.rmtree(star_temp1)
             if os.path.isdir(star_temp2):
                 shutil.rmtree(star_temp2)
-            if self.clean and not self.keep_discarded_files and self.temp_folder != self.output_folder:
+            if (
+                self.clean
+                and not self.keep_discarded_files
+                and self.temp_folder != self.output_folder
+            ):
                 shutil.rmtree(self.temp_folder)
 
     def sanityCheck(self) -> None:
@@ -203,9 +207,7 @@ class Pipeline:
 
         # Check for presence of 'mapped.bam' if --disable-mapping is set
         if self.disable_mapping and not os.path.exists(os.path.join(self.temp_folder, FILENAMES["mapped"])):  # type: ignore[call-overload]
-            error = (
-                f"Error argument '--disable-mapping' is set but {FILENAMES['mapped']} is missing in {self.temp_folder}."
-            )
+            error = f"Error argument '--disable-mapping' is set but {FILENAMES['mapped']} is missing in {self.temp_folder}."
             logger.error(error)
             raise RuntimeError(error)
 
@@ -220,7 +222,9 @@ class Pipeline:
             raise RuntimeError(error)
 
         if self.saturation_points is not None and not self.compute_saturation:
-            logger.warning("Saturation points are provided but the option to compute saturation is disabled.")
+            logger.warning(
+                "Saturation points are provided but the option to compute saturation is disabled."
+            )
 
         if not self.disable_umi and self.umi_filter:
             # Check template validity
@@ -230,7 +234,9 @@ class Pipeline:
                 logger.error(error)
                 raise RuntimeError(error)
             # Check template length
-            if len(self.umi_filter_template) != (self.umi_end_position - self.umi_start_position):
+            if len(self.umi_filter_template) != (
+                self.umi_end_position - self.umi_start_position
+            ):
                 error = f"Error the UMI template given does not have the correct length {self.umi_filter_template}."
                 logger.error(error)
                 raise RuntimeError(error)
@@ -273,9 +279,7 @@ class Pipeline:
 
         # Add checks for trimming parameters, demultiplex parameters and UMI parameters
         if self.allowed_missed > self.allowed_kmer and not self.disable_barcode:
-            error = (
-                "Error starting the pipeline.\nTaggd allowed mismatches is bigger or equal than the Taggd k-mer size"
-            )
+            error = "Error starting the pipeline.\nTaggd allowed mismatches is bigger or equal than the Taggd k-mer size"
             logger.error(error)
             raise RuntimeError(error)
 
@@ -291,7 +295,11 @@ class Pipeline:
             logger.error(error)
             raise RuntimeError(error)
 
-        if self.umi_allowed_mismatches > (self.umi_end_position - self.umi_start_position) and not self.disable_umi:
+        if (
+            self.umi_allowed_mismatches
+            > (self.umi_end_position - self.umi_start_position)
+            and not self.disable_umi
+        ):
             error = "Error starting the pipeline.\nThe allowed UMI mismatches is bigger than the UMI size"
             logger.error(error)
             raise RuntimeError(error)
@@ -312,7 +320,9 @@ class Pipeline:
             logger.error(error)
             raise RuntimeError(error)
 
-    def createParameters(self, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    def createParameters(
+        self, parser: argparse.ArgumentParser
+    ) -> argparse.ArgumentParser:
         """
         Adds the pipeline"s parameters to a given
         Argparse object and returns it.
@@ -322,11 +332,15 @@ class Pipeline:
             def __call__(self, parser, namespace, values, option_string=None) -> None:  # type: ignore
                 prospective_dir = values
                 if not os.path.isdir(prospective_dir):
-                    raise argparse.ArgumentTypeError(f"{prospective_dir} is not a valid path")
+                    raise argparse.ArgumentTypeError(
+                        f"{prospective_dir} is not a valid path"
+                    )
                 if os.access(prospective_dir, os.R_OK):
                     setattr(namespace, self.dest, prospective_dir)
                 else:
-                    raise argparse.ArgumentTypeError(f"{prospective_dir} is not a readable dir")
+                    raise argparse.ArgumentTypeError(
+                        f"{prospective_dir} is not a readable dir"
+                    )
 
         parser.add_argument("fastq_files", nargs=2)
         parser.add_argument(
@@ -371,7 +385,10 @@ class Pipeline:
             help="Do not remove temporary/intermediary files (useful for debugging)",
         )
         parser.add_argument(
-            "--verbose", action="store_true", default=False, help="Show extra information on the log file"
+            "--verbose",
+            action="store_true",
+            default=False,
+            help="Show extra information on the log file",
         )
         parser.add_argument(
             "--threads",
@@ -395,7 +412,11 @@ class Pipeline:
             help="Name of the file that we want to use to store the logs (default output to screen)",
         )
         parser.add_argument(
-            "--output-folder", metavar="[FOLDER]", action=readable_dir, default=None, help="Path of the output folder"
+            "--output-folder",
+            metavar="[FOLDER]",
+            action=readable_dir,
+            default=None,
+            help="Path of the output folder",
         )
         parser.add_argument(
             "--temp-folder",
@@ -409,6 +430,12 @@ class Pipeline:
             action="store_true",
             default=False,
             help="Keep files with discarded reads in every step",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            default=False,
+            help="Force overwriting existing files",
         )
         parser.add_argument(
             "--qual-64",
@@ -456,7 +483,8 @@ class Pipeline:
             metavar="[INT]",
             type=int,
             choices=range(0, 35),
-            help="Remove PolyG stretches of the given length from R2 " "(Use 0 to disable it) (default: %(default)s)",
+            help="Remove PolyG stretches of the given length from R2 "
+            "(Use 0 to disable it) (default: %(default)s)",
         )
         parser.add_argument(
             "--remove-polyC",
@@ -586,7 +614,8 @@ class Pipeline:
             "--star-min-score-ratio",
             default=0.66,
             type=float,
-            help="Minimum alignment score (as above) but normalized to" "\nread length. (default: 0.66)",
+            help="Minimum alignment score (as above) but normalized to"
+            "\nread length. (default: 0.66)",
         )
         parser.add_argument(
             "--star-min-matched-bases",
@@ -601,7 +630,8 @@ class Pipeline:
             "--star-min-matched-bases-ratio",
             default=0.66,
             type=float,
-            help="Minimum matched bases (as above) but normalized to" "\nread length. (default: 0.66)",
+            help="Minimum matched bases (as above) but normalized to"
+            "\nread length. (default: 0.66)",
         )
         parser.add_argument(
             "--demultiplexing-mismatches",
@@ -832,7 +862,9 @@ class Pipeline:
             help="Use this flag if you want to use transcriptome instead of a genome, the gene tag will be "
             "obtained from the transcriptome file",
         )
-        parser.add_argument("--version", action="version", version="%(prog)s " + str(version_number))
+        parser.add_argument(
+            "--version", action="version", version="%(prog)s " + str(version_number)
+        )
         return parser
 
     def load_parameters(self, options: argparse.Namespace) -> None:
@@ -880,6 +912,7 @@ class Pipeline:
         self.umi_start_position = options.umi_start_position
         self.umi_end_position = options.umi_end_position
         self.keep_discarded_files = options.keep_discarded_files
+        self.force = options.force
         self.remove_polyA_distance = options.remove_polyA
         self.remove_polyT_distance = options.remove_polyT
         self.remove_polyG_distance = options.remove_polyG
@@ -902,7 +935,9 @@ class Pipeline:
         self.umi_quality_bases = options.umi_quality_bases
         self.umi_counting_offset = options.umi_counting_offset
         self.taggd_metric = options.demultiplexing_metric
-        self.taggd_multiple_hits_keep_one = options.demultiplexing_multiple_hits_keep_one
+        self.taggd_multiple_hits_keep_one = (
+            options.demultiplexing_multiple_hits_keep_one
+        )
         self.taggd_trim_sequences = options.demultiplexing_trim_sequences
         self.taggd_chunk_size = options.demultiplexing_chunk_size
         self.adaptor_missmatches = options.homopolymer_mismatches
@@ -921,7 +956,11 @@ class Pipeline:
             self.saturation_points = [int(p) for p in options.saturation_points]  # type: ignore
         # Assign class parameters to the QA stats object
         attributes = inspect.getmembers(self, lambda a: not (inspect.isroutine(a)))
-        attributes_filtered = {a[0]: a[1] for a in attributes if not (a[0].startswith("__") and a[0].endswith("__"))}
+        attributes_filtered = {
+            a[0]: a[1]
+            for a in attributes
+            if not (a[0].startswith("__") and a[0].endswith("__"))
+        }
         # Assign general parameters to the qa_stats object
         self.qa_stats.input_parameters = attributes_filtered  # type: ignore
         self.qa_stats.annotation_tool = f"htseq-count {get_htseq_count_version()}"
@@ -951,25 +990,45 @@ class Pipeline:
         if self.ref_annotation is not None:
             logger.info(f"Reference annotation file: {self.ref_annotation}")
         if self.contaminant_index is not None:
-            logger.info(f"Using contamination filter STAR index: {self.contaminant_index}")
+            logger.info(
+                f"Using contamination filter STAR index: {self.contaminant_index}"
+            )
         logger.info(f"CPU Nodes: {self.threads}")
 
         if not self.disable_trimming:
             logger.info("Quality and trimming settings")
-            logger.info(f"Discarding reads that after trimming are shorter than {self.min_length_trimming}")
+            logger.info(
+                f"Discarding reads that after trimming are shorter than {self.min_length_trimming}"
+            )
             if self.remove_polyA_distance > 0:
-                logger.info(f"Removing polyA sequences of a length of at least: {self.remove_polyA_distance}")
+                logger.info(
+                    f"Removing polyA sequences of a length of at least: {self.remove_polyA_distance}"
+                )
             if self.remove_polyT_distance > 0:
-                logger.info(f"Removing polyT sequences of a length of at least: {self.remove_polyT_distance}")
+                logger.info(
+                    f"Removing polyT sequences of a length of at least: {self.remove_polyT_distance}"
+                )
             if self.remove_polyG_distance > 0:
-                logger.info(f"Removing polyG sequences of a length of at least: {self.remove_polyG_distance}")
+                logger.info(
+                    f"Removing polyG sequences of a length of at least: {self.remove_polyG_distance}"
+                )
             if self.remove_polyC_distance > 0:
-                logger.info(f"Removing polyC sequences of a length of at least: {self.remove_polyC_distance}")
+                logger.info(
+                    f"Removing polyC sequences of a length of at least: {self.remove_polyC_distance}"
+                )
             if self.remove_polyN_distance > 0:
-                logger.info(f"Removing polyN sequences of a length of at least: {self.remove_polyN_distance}")
-            logger.info(f"Allowing {self.adaptor_missmatches} mismatches when removing homopolymers")
-            logger.info(f"Discarding reads whose AT content is {self.filter_AT_content}%")
-            logger.info(f"Discarding reads whose GC content is {self.filter_GC_content}%")
+                logger.info(
+                    f"Removing polyN sequences of a length of at least: {self.remove_polyN_distance}"
+                )
+            logger.info(
+                f"Allowing {self.adaptor_missmatches} mismatches when removing homopolymers"
+            )
+            logger.info(
+                f"Discarding reads whose AT content is {self.filter_AT_content}%"
+            )
+            logger.info(
+                f"Discarding reads whose GC content is {self.filter_GC_content}%"
+            )
         else:
             logger.info("Disabling Quality trimming step")
 
@@ -978,12 +1037,20 @@ class Pipeline:
             logger.info(f"Mapping reverse trimming: {self.trimming_rv}")
             logger.info(f"Mapping inverse reverse trimming: {self.inverse_trimming_rv}")
             logger.info("Mapping tool: STAR")
-            logger.info(f"Mapping minimum intron size allowed (splice alignments) with STAR: {self.min_intron_size}")
-            logger.info(f"Mapping maximum intron size allowed (splice alignments) with STAR: {self.max_intron_size}")
+            logger.info(
+                f"Mapping minimum intron size allowed (splice alignments) with STAR: {self.min_intron_size}"
+            )
+            logger.info(
+                f"Mapping maximum intron size allowed (splice alignments) with STAR: {self.max_intron_size}"
+            )
             logger.info(f"STAR genome loading strategy: {self.star_genome_loading}")
             logger.info(f"STAR minimum alignment score: {self.star_min_score}")
-            logger.info(f"STAR minimum alignment score ratio: {self.star_min_score_ratio}")
-            logger.info(f"STAR minimum matched bases ratio: {self.star_min_matched_bases_ratio}")
+            logger.info(
+                f"STAR minimum alignment score ratio: {self.star_min_score_ratio}"
+            )
+            logger.info(
+                f"STAR minimum matched bases ratio: {self.star_min_matched_bases_ratio}"
+            )
             if self.disable_clipping:
                 logger.info("Not allowing soft clipping when mapping with STAR")
             if self.disable_multimap:
@@ -1003,7 +1070,9 @@ class Pipeline:
             if self.taggd_multiple_hits_keep_one:
                 logger.info("TaggD multiple hits keep one (random) is enabled")
             if self.taggd_trim_sequences is not None:
-                logger.info(f"TaggD trimming from the barcodes: {'-'.join(str(x) for x in self.taggd_trim_sequences)}")
+                logger.info(
+                    f"TaggD trimming from the barcodes: {'-'.join(str(x) for x in self.taggd_trim_sequences)}"
+                )
             logger.info(f"TaggD chunk size: {self.taggd_chunk_size }")
         else:
             logger.info("Disabling Demultiplexing step")
@@ -1026,7 +1095,9 @@ class Pipeline:
         if self.compute_saturation:
             logger.info("Computing saturation curve with several sub-samples...")
             if self.saturation_points is not None:
-                logger.info(f"Using the following points: {' '.join(str(p) for p in self.saturation_points)}")
+                logger.info(
+                    f"Using the following points: {' '.join(str(p) for p in self.saturation_points)}"
+                )
 
         if not self.disable_umi:
             logger.info("UMI Collapsing settings")
@@ -1037,7 +1108,9 @@ class Pipeline:
             logger.info(
                 f"Allowing an offset of {self.umi_counting_offset} when clustering UMIs by strand-start in a gene-spot"
             )
-            logger.info(f"Allowing {self.umi_quality_bases} low quality bases in an UMI")
+            logger.info(
+                f"Allowing {self.umi_quality_bases} low quality bases in an UMI"
+            )
             if self.umi_filter:
                 logger.info(f"UMIs using filter: {self.umi_filter_template}")
         else:
@@ -1073,14 +1146,18 @@ class Pipeline:
         # Get the barcode length
         barcode_length = len(list(read_barcode_file(self.ids).values())[0].sequence)
         # Check if quality trimmed file exists
-        if not os.path.exists(FILENAMES["quality_trimmed_R2"]):
+        if not os.path.exists(FILENAMES["quality_trimmed_R2"]) or self.force:
             logger.info(f"Start filtering raw reads {globaltime.get_timestamp()}")
             try:
                 stats = filter_input_data(
                     self.fastq_fw,
                     self.fastq_rv,
                     FILENAMES["quality_trimmed_R2"],
-                    FILENAMES_DISCARDED["quality_trimmed_discarded"] if self.keep_discarded_files else None,
+                    (
+                        FILENAMES_DISCARDED["quality_trimmed_discarded"]
+                        if self.keep_discarded_files
+                        else None
+                    ),
                     barcode_length,
                     self.barcode_start,
                     self.filter_AT_content,
@@ -1111,7 +1188,9 @@ class Pipeline:
             except Exception:
                 raise
         else:
-            logger.info(f"Using already existing {FILENAMES["quality_trimmed_R2"]} file")
+            logger.info(
+                f"Using already existing {FILENAMES['quality_trimmed_R2']} file"
+            )
 
         # =================================================================
         # CONDITIONAL STEP: Filter out contaminated reads, e.g. rRNA(Optional)
@@ -1119,7 +1198,9 @@ class Pipeline:
         if self.contaminant_index:
             # To remove contaminants sequence we align the reads to the contaminant genome
             # and keep the un-mapped reads
-            logger.info(f"Starting contaminant filter alignment {globaltime.get_timestamp()}")
+            logger.info(
+                f"Starting contaminant filter alignment {globaltime.get_timestamp()}"
+            )
             try:
                 # Make the contaminant filter call
                 alignReads(
@@ -1148,9 +1229,15 @@ class Pipeline:
                 # NOTE: this will not be needed when STAR allows to chose the discarded
                 # reads format (BAM)
                 # We also need to set the NH tag to Null so to be able to run STAR again
-                infile = pysam.AlignmentFile(FILENAMES_DISCARDED["contaminated_discarded"], "rb")
-                out_unmap = pysam.AlignmentFile(FILENAMES["contaminated_clean"], "wb", template=infile)
-                temp_name = os.path.join(self.temp_folder, next(tempfile._get_candidate_names()))
+                infile = pysam.AlignmentFile(
+                    FILENAMES_DISCARDED["contaminated_discarded"], "rb"
+                )
+                out_unmap = pysam.AlignmentFile(
+                    FILENAMES["contaminated_clean"], "wb", template=infile
+                )
+                temp_name = os.path.join(
+                    self.temp_folder, next(tempfile._get_candidate_names())
+                )
                 out_map = pysam.AlignmentFile(temp_name, "wb", template=infile)
                 for sam_record in infile.fetch(until_eof=True):
                     try:
@@ -1179,7 +1266,9 @@ class Pipeline:
         # =================================================================
         if not self.disable_mapping:
             input_mapping = (
-                FILENAMES["contaminated_clean"] if self.contaminant_index else FILENAMES["quality_trimmed_R2"]
+                FILENAMES["contaminated_clean"]
+                if self.contaminant_index
+                else FILENAMES["quality_trimmed_R2"]
             )
             logger.info(f"Starting genome alignment {globaltime.get_timestamp()}")
             try:
@@ -1213,7 +1302,10 @@ class Pipeline:
                     temp_name = os.path.join(self.temp_folder, next(tempfile._get_candidate_names()))  # type: ignore
                     # Note use 260 to also discard multiple-alignments
                     command = "samtools view -b -h -F 4 -@ {} -o {} -U {} {}".format(
-                        self.threads, temp_name, FILENAMES_DISCARDED["mapped_discarded"], FILENAMES["mapped"]
+                        self.threads,
+                        temp_name,
+                        FILENAMES_DISCARDED["mapped_discarded"],
+                        FILENAMES["mapped"],
                     )
                     subprocess.check_call(command, shell=True)
                     os.rename(temp_name, FILENAMES["mapped"])
@@ -1224,8 +1316,10 @@ class Pipeline:
         # STEP: DEMULTIPLEX READS Map against the barcodes (Optional)
         # =================================================================
         if not self.disable_barcode:
-            if not os.path.exists(FILENAMES["demultiplexed_matched"]):
-                logger.info(f"Starting barcode demultiplexing {globaltime.get_timestamp()}")
+            if not os.path.exists(FILENAMES["demultiplexed_matched"]) or self.force:
+                logger.info(
+                    f"Starting barcode demultiplexing {globaltime.get_timestamp()}"
+                )
                 try:
                     stats = barcodeDemultiplexing(  # type: ignore
                         FILENAMES["mapped"],
@@ -1255,7 +1349,9 @@ class Pipeline:
                 except Exception:
                     raise
             else:
-                logger.info(f"Using already existing {FILENAMES["demultiplexed_matched"]} file")
+                logger.info(
+                    f"Using already existing {FILENAMES['demultiplexed_matched']} file"
+                )
         else:
             FILENAMES["demultiplexed_matched"] = FILENAMES["mapped"]
 
@@ -1264,7 +1360,9 @@ class Pipeline:
         # =================================================================
         if not self.disable_annotation:
             if self.transcriptome:
-                logger.info(f"Assigning gene names from transcriptome {globaltime.get_timestamp()}")
+                logger.info(
+                    f"Assigning gene names from transcriptome {globaltime.get_timestamp()}"
+                )
                 # Iterate the BAM file to set the gene name as the transcriptome"s entry
                 flag_read = "rb"
                 flag_write = "wb"
@@ -1284,7 +1382,11 @@ class Pipeline:
                         FILENAMES["demultiplexed_matched"],
                         self.ref_annotation,  # type: ignore
                         FILENAMES["annotated"],
-                        FILENAMES_DISCARDED["annotated_discarded"] if self.keep_discarded_files else None,
+                        (
+                            FILENAMES_DISCARDED["annotated_discarded"]
+                            if self.keep_discarded_files
+                            else None
+                        ),
                         self.htseq_mode,
                         self.strandness,
                         self.htseq_no_ambiguous,
@@ -1307,7 +1409,9 @@ class Pipeline:
                 if not self.transcriptome
                 else self.qa_stats.reads_after_demultiplexing
             )
-            logger.info(f"Starting computing saturation points {globaltime.get_timestamp()}")
+            logger.info(
+                f"Starting computing saturation points {globaltime.get_timestamp()}"
+            )
             try:
                 compute_saturation(
                     nreads,

--- a/stpipeline/core/pipeline.py
+++ b/stpipeline/core/pipeline.py
@@ -1072,42 +1072,46 @@ class Pipeline:
         # =================================================================
         # Get the barcode length
         barcode_length = len(list(read_barcode_file(self.ids).values())[0].sequence)
-        logger.info(f"Start filtering raw reads {globaltime.get_timestamp()}")
-        try:
-            stats = filter_input_data(
-                self.fastq_fw,
-                self.fastq_rv,
-                FILENAMES["quality_trimmed_R2"],
-                FILENAMES_DISCARDED["quality_trimmed_discarded"] if self.keep_discarded_files else None,
-                barcode_length,
-                self.barcode_start,
-                self.filter_AT_content,
-                self.filter_GC_content,
-                self.umi_start_position,
-                self.umi_end_position,
-                self.min_quality_trimming,
-                self.min_length_trimming,
-                self.remove_polyA_distance,
-                self.remove_polyT_distance,
-                self.remove_polyG_distance,
-                self.remove_polyC_distance,
-                self.remove_polyN_distance,
-                self.qual64,
-                self.umi_filter,
-                self.umi_filter_template,
-                self.umi_quality_bases,
-                self.adaptor_missmatches,
-                self.overhang,
-                self.disable_umi,
-                self.disable_barcode,
-                self.disable_trimming,
-            )
-            # update qa_stats
-            self.qa_stats.input_reads_reverse = stats[0]
-            self.qa_stats.reads_after_trimming_forward = stats[1]
-            self.qa_stats.reads_after_trimming_reverse = stats[1]
-        except Exception:
-            raise
+        # Check if quality trimmed file exists
+        if not os.path.exists(FILENAMES["quality_trimmed_R2"]):
+            logger.info(f"Start filtering raw reads {globaltime.get_timestamp()}")
+            try:
+                stats = filter_input_data(
+                    self.fastq_fw,
+                    self.fastq_rv,
+                    FILENAMES["quality_trimmed_R2"],
+                    FILENAMES_DISCARDED["quality_trimmed_discarded"] if self.keep_discarded_files else None,
+                    barcode_length,
+                    self.barcode_start,
+                    self.filter_AT_content,
+                    self.filter_GC_content,
+                    self.umi_start_position,
+                    self.umi_end_position,
+                    self.min_quality_trimming,
+                    self.min_length_trimming,
+                    self.remove_polyA_distance,
+                    self.remove_polyT_distance,
+                    self.remove_polyG_distance,
+                    self.remove_polyC_distance,
+                    self.remove_polyN_distance,
+                    self.qual64,
+                    self.umi_filter,
+                    self.umi_filter_template,
+                    self.umi_quality_bases,
+                    self.adaptor_missmatches,
+                    self.overhang,
+                    self.disable_umi,
+                    self.disable_barcode,
+                    self.disable_trimming,
+                )
+                # update qa_stats
+                self.qa_stats.input_reads_reverse = stats[0]
+                self.qa_stats.reads_after_trimming_forward = stats[1]
+                self.qa_stats.reads_after_trimming_reverse = stats[1]
+            except Exception:
+                raise
+        else:
+            logger.info(f"Using already existing {FILENAMES["quality_trimmed_R2"]} file")
 
         # =================================================================
         # CONDITIONAL STEP: Filter out contaminated reads, e.g. rRNA(Optional)
@@ -1220,35 +1224,38 @@ class Pipeline:
         # STEP: DEMULTIPLEX READS Map against the barcodes (Optional)
         # =================================================================
         if not self.disable_barcode:
-            logger.info(f"Starting barcode demultiplexing {globaltime.get_timestamp()}")
-            try:
-                stats = barcodeDemultiplexing(  # type: ignore
-                    FILENAMES["mapped"],
-                    self.ids,
-                    self.allowed_missed,
-                    self.allowed_kmer,
-                    self.overhang,
-                    self.taggd_metric,
-                    self.taggd_multiple_hits_keep_one,
-                    self.taggd_trim_sequences,
-                    self.threads,
-                    FILENAMES["demultiplexed_prefix"],  # Prefix for output files
-                    self.keep_discarded_files,
-                    self.taggd_chunk_size,
-                )
-                # pdate qa_stats
-                self.qa_stats.reads_after_demultiplexing = stats  # type: ignore
+            if not os.path.exists(FILENAMES["demultiplexed_matched"]):
+                logger.info(f"Starting barcode demultiplexing {globaltime.get_timestamp()}")
+                try:
+                    stats = barcodeDemultiplexing(  # type: ignore
+                        FILENAMES["mapped"],
+                        self.ids,
+                        self.allowed_missed,
+                        self.allowed_kmer,
+                        self.overhang,
+                        self.taggd_metric,
+                        self.taggd_multiple_hits_keep_one,
+                        self.taggd_trim_sequences,
+                        self.threads,
+                        FILENAMES["demultiplexed_prefix"],  # Prefix for output files
+                        self.keep_discarded_files,
+                        self.taggd_chunk_size,
+                    )
+                    # pdate qa_stats
+                    self.qa_stats.reads_after_demultiplexing = stats  # type: ignore
 
-                # TODO TaggD does not output the BAM file sorted
-                command = "samtools sort -T {}/sort_bam -@ {} -o {} {}".format(
-                    self.temp_folder,
-                    self.threads,
-                    FILENAMES["demultiplexed_matched"],
-                    FILENAMES["demultiplexed_matched"],
-                )
-                subprocess.check_call(command, shell=True)
-            except Exception:
-                raise
+                    # TODO TaggD does not output the BAM file sorted
+                    command = "samtools sort -T {}/sort_bam -@ {} -o {} {}".format(
+                        self.temp_folder,
+                        self.threads,
+                        FILENAMES["demultiplexed_matched"],
+                        FILENAMES["demultiplexed_matched"],
+                    )
+                    subprocess.check_call(command, shell=True)
+                except Exception:
+                    raise
+            else:
+                logger.info(f"Using already existing {FILENAMES["demultiplexed_matched"]} file")
         else:
             FILENAMES["demultiplexed_matched"] = FILENAMES["mapped"]
 


### PR DESCRIPTION
# Description
This pull request adds checks for already existing output files (_e.g._ from previous st-pipeline runs) and skips the corresponding steps if the files exist. A `--force` command-line argument is added to force overwriting existing files. Currently only the `quality_trimmed_R2` and `demultiplexed_matched` output files are checked.

This allows more fine-grained control of what steps are run, helps with tuning resources when running on clusters and gives more flexibility in file organization.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
